### PR TITLE
feat: Janee integration for audited secrets management

### DIFF
--- a/docker-compose.janee.yml
+++ b/docker-compose.janee.yml
@@ -1,0 +1,35 @@
+# Optional: Janee secrets management for OpenSeed
+# Usage: docker compose -f docker-compose.yml -f docker-compose.janee.yml up
+#
+# This adds Janee (https://github.com/rsdouglas/janee) as a secrets manager
+# for your creature API keys. Benefits:
+#   - Full audit trail of every API call per creature
+#   - Per-creature access policies (e.g., read-only Stripe)
+#   - Instant key revocation without restarting creatures
+#   - Keys never exposed to creature containers
+#
+# Setup:
+#   1. Install Janee: npm install -g @true-and-useful/janee
+#   2. Initialize: janee init
+#   3. Add your API keys: janee add anthropic --bearer sk-ant-xxx
+#   4. Start with: docker compose -f docker-compose.yml -f docker-compose.janee.yml up
+
+services:
+  janee:
+    image: node:20-slim
+    container_name: janee
+    restart: unless-stopped
+    working_dir: /app
+    command: >
+      sh -c "npm install -g @true-and-useful/janee &&
+             janee serve --transport http --host 0.0.0.0 --port 9100"
+    ports:
+      - "9100:9100"
+    volumes:
+      - ${JANEE_HOME:-~/.janee}:/root/.janee
+    networks:
+      - openseed
+
+  openseed:
+    environment:
+      - JANEE_ENDPOINT=http://janee:9100

--- a/docs/janee-integration.md
+++ b/docs/janee-integration.md
@@ -1,0 +1,124 @@
+# Janee Secrets Management Integration
+
+[Janee](https://github.com/rsdouglas/janee) is an open-source MCP server for managing API secrets. When integrated with OpenSeed, it provides:
+
+- **Audit trails** — every API key access is logged with creature name, timestamp, and service
+- **Per-creature policies** — restrict which creatures can access which APIs
+- **Instant revocation** — revoke a creature's API access without restarting anything
+- **Zero-knowledge creatures** — creatures never see raw API keys
+
+## How It Works
+
+```
+┌──────────┐     ┌──────────┐     ┌───────┐     ┌──────────┐
+│ Creature │────▶│ OpenSeed │────▶│ Janee │────▶│ Anthropic│
+│          │     │  Proxy   │     │       │     │ / OpenAI │
+└──────────┘     └──────────┘     └───────┘     └──────────┘
+                      │                │
+                      │ "Give me the   │ ✓ Logs access
+                      │  Anthropic key │ ✓ Checks policy
+                      │  for creature  │ ✓ Returns key
+                      │  'atlas'"      │   (cached 5 min)
+```
+
+Without Janee, OpenSeed reads `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from environment variables. With Janee, these are fetched on-demand with full audit logging.
+
+## Quick Start
+
+### 1. Install Janee
+
+```bash
+npm install -g @true-and-useful/janee
+janee init
+```
+
+### 2. Add Your API Keys
+
+```bash
+janee add anthropic --bearer sk-ant-api03-xxxxx
+janee add openai --bearer sk-xxxxx
+```
+
+### 3. Start with Docker Compose
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.janee.yml up
+```
+
+This starts Janee alongside OpenSeed. The proxy automatically detects the `JANEE_ENDPOINT` environment variable and fetches credentials from Janee instead of env vars.
+
+### 4. Verify
+
+Check Janee's audit log to see credential access events:
+
+```bash
+janee logs
+```
+
+You'll see entries like:
+```
+2025-01-15 10:23:45 | anthropic | request_access | OpenSeed LLM proxy for creature: atlas
+2025-01-15 10:23:47 | openai    | request_access | OpenSeed LLM proxy for creature: eve
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `JANEE_ENDPOINT` | (none) | Janee HTTP endpoint. Set to enable integration. |
+| `JANEE_HOME` | `~/.janee` | Janee config directory (for Docker volume mount) |
+
+### Graceful Fallback
+
+If Janee is unavailable or a credential isn't configured there, the proxy falls back to environment variables (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). This means you can:
+
+1. Start with env vars only (no Janee)
+2. Add Janee later without changing your creature configs
+3. Keep env vars as a backup during Janee migration
+
+### Per-Creature Access Control
+
+In your Janee config (`~/.janee/config.yaml`), define capabilities per service:
+
+```yaml
+services:
+  anthropic:
+    baseUrl: https://api.anthropic.com
+    auth: { type: bearer, key: sk-ant-xxx }
+  openai:
+    baseUrl: https://api.openai.com
+    auth: { type: bearer, key: sk-xxx }
+
+capabilities:
+  anthropic-readonly:
+    service: anthropic
+    ttl: 1h
+    rules:
+      allow: ["POST /v1/messages"]
+      deny: ["*"]
+  openai-full:
+    service: openai
+    ttl: 4h
+    autoApprove: true
+```
+
+## Local Development (without Docker)
+
+```bash
+# Terminal 1: Start Janee
+janee serve --transport http --port 9100
+
+# Terminal 2: Start OpenSeed with Janee
+JANEE_ENDPOINT=http://localhost:9100 openseed start
+```
+
+## Revoking Access
+
+When a creature is stopped or its budget is exceeded, OpenSeed automatically calls `janee.revokeAccess()` to clean up the session. You can also revoke manually:
+
+```bash
+janee sessions              # List active sessions
+janee sessions revoke <id>  # Revoke a specific session
+```

--- a/src/host/janee.ts
+++ b/src/host/janee.ts
@@ -1,0 +1,216 @@
+/**
+ * Janee Integration for OpenSeed
+ *
+ * Optional secrets management via Janee MCP server.
+ * When enabled, API keys are fetched from Janee instead of environment variables,
+ * giving per-creature audit trails, access policies, and instant revocation.
+ *
+ * @see https://github.com/rsdouglas/janee
+ */
+
+interface JaneeSession {
+  sessionId: string;
+  expiresAt: number;
+  service: string;
+}
+
+interface JaneeConfig {
+  /** Janee HTTP endpoint (default: http://janee:9100 in Docker, http://localhost:9100 otherwise) */
+  endpoint: string;
+  /** Whether Janee integration is enabled */
+  enabled: boolean;
+  /** Cache TTL in ms for fetched credentials (default: 300000 = 5 min) */
+  cacheTtlMs: number;
+}
+
+interface CachedCredential {
+  value: string;
+  expiresAt: number;
+}
+
+/**
+ * Client for fetching API credentials from a Janee MCP server.
+ *
+ * Janee's HTTP transport exposes standard MCP tool calls over REST.
+ * We call the `execute` tool to proxy requests, but for the LLM proxy
+ * use case we need the raw credential to forward to upstream APIs.
+ *
+ * Flow:
+ *   1. OpenSeed starts, connects to Janee if JANEE_ENDPOINT is set
+ *   2. For each LLM request, proxy checks Janee for the API key
+ *   3. Janee logs the access (creature name, timestamp, service)
+ *   4. Key is cached briefly to avoid per-request latency
+ */
+export class JaneeClient {
+  private config: JaneeConfig;
+  private cache: Map<string, CachedCredential> = new Map();
+
+  constructor(config?: Partial<JaneeConfig>) {
+    const isDocker = process.env.OPENSEED_DOCKER === '1';
+    this.config = {
+      endpoint: config?.endpoint || process.env.JANEE_ENDPOINT ||
+        (isDocker ? 'http://janee:9100' : 'http://localhost:9100'),
+      enabled: config?.enabled ?? !!process.env.JANEE_ENDPOINT,
+      cacheTtlMs: config?.cacheTtlMs ?? 300_000,
+    };
+  }
+
+  get enabled(): boolean {
+    return this.config.enabled;
+  }
+
+  /**
+   * Fetch an API key for a given service, with per-creature audit logging.
+   * Falls back to null if Janee is unavailable (caller should fall back to env vars).
+   */
+  async getCredential(
+    service: string,
+    creatureName: string,
+  ): Promise<string | null> {
+    if (!this.config.enabled) return null;
+
+    // Check cache first
+    const cacheKey = `${service}:${creatureName}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    try {
+      // Call Janee's MCP HTTP endpoint to request credential access
+      // This creates an audited session in Janee's logs
+      const resp = await fetch(`${this.config.endpoint}/mcp`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: {
+            name: 'request_access',
+            arguments: {
+              capability: service,
+              reason: `OpenSeed LLM proxy for creature: ${creatureName}`,
+            },
+          },
+        }),
+      });
+
+      if (!resp.ok) {
+        console.warn(`[janee] credential fetch failed for ${service}: HTTP ${resp.status}`);
+        return null;
+      }
+
+      const result = await resp.json() as any;
+      const content = result?.result?.content;
+      if (!content || !Array.isArray(content)) {
+        console.warn(`[janee] unexpected response format for ${service}`);
+        return null;
+      }
+
+      // Extract session token from response
+      const textBlock = content.find((c: any) => c.type === 'text');
+      if (!textBlock?.text) return null;
+
+      try {
+        const session = JSON.parse(textBlock.text);
+        if (session.credential) {
+          // Cache the credential
+          this.cache.set(cacheKey, {
+            value: session.credential,
+            expiresAt: Date.now() + this.config.cacheTtlMs,
+          });
+          return session.credential;
+        }
+      } catch {
+        // Response wasn't JSON, might be a status message
+        console.warn(`[janee] could not parse credential response for ${service}`);
+      }
+
+      return null;
+    } catch (err: any) {
+      console.warn(`[janee] connection error: ${err.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Check if Janee is reachable and healthy.
+   */
+  async healthCheck(): Promise<boolean> {
+    if (!this.config.enabled) return false;
+
+    try {
+      const resp = await fetch(`${this.config.endpoint}/mcp`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/list',
+          params: {},
+        }),
+      });
+      return resp.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Revoke a creature's access to a service.
+   * Called when a creature is stopped or its budget is exceeded.
+   */
+  async revokeAccess(service: string, creatureName: string): Promise<void> {
+    if (!this.config.enabled) return;
+
+    // Clear local cache
+    this.cache.delete(`${service}:${creatureName}`);
+
+    try {
+      await fetch(`${this.config.endpoint}/mcp`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: {
+            name: 'revoke_session',
+            arguments: {
+              service,
+              reason: `OpenSeed revoked access for creature: ${creatureName}`,
+            },
+          },
+        }),
+      });
+    } catch (err: any) {
+      console.warn(`[janee] revoke error: ${err.message}`);
+    }
+  }
+
+  /**
+   * Clear the credential cache (useful on config reload).
+   */
+  clearCache(): void {
+    this.cache.clear();
+  }
+}
+
+/**
+ * Singleton Janee client for the orchestrator.
+ * Initialized lazily on first use.
+ */
+let _client: JaneeClient | null = null;
+
+export function getJaneeClient(): JaneeClient {
+  if (!_client) {
+    _client = new JaneeClient();
+    if (_client.enabled) {
+      console.log(`[janee] secrets management enabled, endpoint: ${process.env.JANEE_ENDPOINT || 'auto-detected'}`);
+    }
+  }
+  return _client;
+}


### PR DESCRIPTION
## Summary

Adds optional [Janee](https://github.com/rsdouglas/janee) integration to the LLM proxy layer for audited credential management.

## Problem

Currently, all creatures share the same API keys via environment variables. There's no audit trail of which creature accessed which key, no per-creature access control, and revoking a key requires restarting all creatures.

## Solution

When `JANEE_ENDPOINT` is configured, the proxy fetches API keys from Janee instead of env vars. This provides:

- **Audit trails** — every key access is logged with creature name and timestamp
- **Per-creature policies** — restrict which creatures can access which APIs
- **Instant revocation** — revoke access without restarting anything
- **Zero-knowledge creatures** — creatures never see raw API keys

### Graceful fallback

If Janee is unavailable or a credential isn't found, the proxy falls back to environment variables. This means:
1. Existing deployments work unchanged (zero breaking changes)
2. Janee can be added incrementally
3. Env vars serve as backup during migration

## Changes

- `src/host/janee.ts` — Janee client with 5-minute credential cache and `requestAccess`/`revokeAccess` lifecycle
- `src/host/proxy.ts` — Updated `forwardToOpenAI` and `forwardToAnthropic` to optionally fetch keys from Janee
- `docker-compose.janee.yml` — Optional compose override to run Janee alongside OpenSeed
- `docs/janee-integration.md` — Setup guide, architecture diagram, and configuration reference

## Testing

- Without `JANEE_ENDPOINT`: behaves identically to current code (all tests pass unchanged)
- With `JANEE_ENDPOINT`: credentials fetched from Janee, cached for 5 minutes, with env var fallback

## Related

- [Janee](https://github.com/rsdouglas/janee) — MCP-native secrets management server
- Addresses the creature isolation model's gap around shared credentials