### PR TITLE
fix: sanitize markdown HTML with DOMPurify to prevent XSS

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dompurify": "^3.2.6",
     "html2canvas": "^1.4.1",
     "lucide-react": "^0.575.0",
     "marked": "^17.0.3",

--- a/dashboard/src/components/MindContent.tsx
+++ b/dashboard/src/components/MindContent.tsx
@@ -1,6 +1,5 @@
 import { useState, memo } from 'react';
-import { marked } from 'marked';
-import { esc, timeAgo, summarize } from '@/utils';
+import { esc, timeAgo, summarize, renderMarkdown } from '@/utils';
 import type { MindData } from '@/types';
 
 function JsonlEntry({ entry }: { entry: any }) {
@@ -44,7 +43,7 @@ export const MindContent = memo(function MindContent({ mindData, tabId }: { mind
   }
 
   if (tab.type === 'markdown') {
-    const html = data ? (() => { try { return marked.parse(data) as string; } catch { return esc(data); } })() : 'Empty.';
+    const html = data ? renderMarkdown(data) : 'Empty.';
     return (
       <div
         className="p-4 font-mono text-xs text-text-primary leading-relaxed break-words [&_h1]:text-[15px] [&_h1]:my-4 [&_h2]:text-sm [&_h2]:my-3 [&_h3]:text-[13px] [&_h3]:my-2 [&_p]:my-1 [&_li]:my-0.5 [&_a]:text-accent-blue [&_code]:bg-[#f0f0f0] [&_code]:px-1 [&_code]:rounded [&_code]:text-xs [&_pre]:bg-[#f5f5f5] [&_pre]:p-2 [&_pre]:rounded [&_pre]:overflow-x-auto [&_pre]:my-2 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:pl-5 [&_ul]:my-1.5 [&_ol]:pl-5 [&_ol]:my-1.5 [&_blockquote]:border-l-[3px] [&_blockquote]:border-[#d0d0d0] [&_blockquote]:pl-3 [&_blockquote]:text-text-secondary [&_blockquote]:my-2 [&_table]:border-collapse [&_table]:my-2 [&_th]:border [&_th]:border-border-light [&_th]:px-2 [&_th]:py-1 [&_th]:text-xs [&_th]:bg-[#f5f5f5] [&_th]:text-text-primary [&_td]:border [&_td]:border-border-light [&_td]:px-2 [&_td]:py-1 [&_td]:text-xs"

--- a/dashboard/src/components/NarrationEntry.tsx
+++ b/dashboard/src/components/NarrationEntry.tsx
@@ -1,5 +1,4 @@
-import { marked } from 'marked';
-import { timeAgo, esc } from '@/utils';
+import { timeAgo, renderMarkdown } from '@/utils';
 import { useStore } from '@/state';
 import type { NarrationEntry as NEntry } from '@/types';
 
@@ -9,9 +8,7 @@ export function NarrationEntry({ entry }: { entry: NEntry }) {
   const selectCreature = useStore(s => s.selectCreature);
   const setShareData = useStore(s => s.setShareData);
 
-  const html = (() => {
-    try { return marked.parse(entry.text) as string; } catch { return esc(entry.text); }
-  })();
+  const html = renderMarkdown(entry.text);
 
   const mentioned = entry.creatures_mentioned || [];
 

--- a/dashboard/src/utils.ts
+++ b/dashboard/src/utils.ts
@@ -1,3 +1,6 @@
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
+
 export function esc(s: string): string {
   const d = document.createElement('div');
   d.textContent = s;
@@ -31,4 +34,14 @@ export function fmtCost(usd: number): string {
 let counter = 0;
 export function uid(): string {
   return 'u' + (++counter) + Math.random().toString(36).slice(2, 6);
+}
+
+/** Sanitized markdown rendering — prevents XSS from creature-generated content. */
+export function renderMarkdown(raw: string): string {
+  try {
+    const html = marked.parse(raw) as string;
+    return DOMPurify.sanitize(html);
+  } catch {
+    return esc(raw);
+  }
 }


### PR DESCRIPTION
Fixes the XSS vulnerability reported in #13.

## Problem

`MindContent.tsx` and `NarrationEntry.tsx` render creature-authored markdown using `marked.parse()` + `dangerouslySetInnerHTML` without sanitization. A creature can inject `<img src=x onerror="...">` (or any other HTML) into its markdown files and execute arbitrary JavaScript in the dashboard user's browser.

## Fix

- **`dompurify`** added as a dependency
- **`renderMarkdown()`** utility added to `utils.ts` — wraps `marked.parse()` with `DOMPurify.sanitize()`, with a fallback to `esc()` if parsing fails
- Both components now use `renderMarkdown()` instead of raw `marked.parse()`

This is the minimal surgical fix. For additional hardening, could also:
- Add `Content-Security-Policy` headers to the dashboard server
- Configure marked with `{ sanitize: true }` (deprecated but belt-and-suspenders)
- Restrict DOMPurify to a specific allowlist of tags/attributes

## Testing

The `<img src=x onerror="alert(...)">` payload from #13 is stripped to `<img src="x">` by DOMPurify — no script execution.