### PR TITLE
fix: sync voyager janee.ts with dreamer — add missing cwd parameter

### DIFF
--- a/genomes/voyager/src/tools/janee.ts
+++ b/genomes/voyager/src/tools/janee.ts
@@ -57,9 +57,6 @@ async function ensureSession(baseUrl: string): Promise<string> {
   if (sid) {
     sessionId = sid;
   } else {
-    // Server may have returned an error (e.g. "already initialized")
-    // but still sent a session ID in a previous response. Try to
-    // proceed without one — some servers accept sessionless calls.
     const text = await res.text();
     const json = parseSSE(text);
     if (json?.error?.message?.includes('already initialized') && json?.error?.data?.sessionId) {
@@ -182,12 +179,14 @@ export async function janeeExecute(args: {
 export async function janeeExec(args: {
   capability: string;
   command: string[];
+  cwd?: string;
   reason?: string;
 }): Promise<string> {
   try {
     const result = await mcpCall('janee_exec', {
       capability: args.capability,
       command: args.command,
+      ...(args.cwd ? { cwd: args.cwd } : {}),
       ...(args.reason ? { reason: args.reason } : {}),
     });
     return JSON.stringify(result, null, 2);
@@ -206,6 +205,7 @@ export async function janee(args: {
   path?: string;
   body?: string | Record<string, unknown>;
   command?: string[];
+  cwd?: string;
   reason?: string;
 }): Promise<string> {
   switch (args.action) {
@@ -234,6 +234,7 @@ export async function janee(args: {
       return janeeExec({
         capability: args.capability,
         command: args.command,
+        cwd: args.cwd,
         reason: args.reason,
       });
 


### PR DESCRIPTION
Voyager's `janee.ts` was missing the `cwd` parameter that was added to dreamer and minimal in d7fd5d9. Creatures running on voyager can't specify a working directory for `janee_exec` even though dreamer/minimal creatures can.

This syncs voyager's `janee.ts` to match dreamer exactly.

Discovered during the shared tools discussion in #34 — this is exactly the kind of drift that proposal aims to prevent.

**Changes:**
- Add `cwd?: string` to `janeeExec()` args and dispatch
- Pass `cwd` through to MCP `janee_exec` call
- Add `cwd` to main `janee()` entry point args
- Remove stale comments that dreamer already cleaned up