### PR TITLE
fix: prevent shell injection in host-side git and genome-extract commands

### DIFF
--- a/src/cli/genome-extract.ts
+++ b/src/cli/genome-extract.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -80,7 +80,7 @@ export async function genomeExtract(opts: ExtractOptions): Promise<void> {
 
   const extractSha = (() => {
     try {
-      return execSync('git rev-parse HEAD', { cwd: srcDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+      return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: srcDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
     } catch { return null; }
   })();
 
@@ -99,7 +99,7 @@ export async function genomeExtract(opts: ExtractOptions): Promise<void> {
   // Init fresh git repo
   execSync('git init', { cwd: dest, stdio: 'ignore' });
   execSync('git add -A', { cwd: dest, stdio: 'ignore' });
-  execSync(`git commit -m "extracted from creature ${opts.creature}"`, { cwd: dest, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', `extracted from creature ${opts.creature}`], { cwd: dest, stdio: 'ignore' });
 
   // Show the diff between birth genome and extracted code
   const birthGenome = birth.genome || 'dreamer';
@@ -109,7 +109,7 @@ export async function genomeExtract(opts: ExtractOptions): Promise<void> {
     const { BUNDLED_GENOMES_DIR } = await import('../shared/paths.js');
     const originalDir = path.join(BUNDLED_GENOMES_DIR, birthGenome);
     if (fs.existsSync(originalDir)) {
-      diffOutput = execSync(`diff -rq "${originalDir}" "${dest}" --exclude=.git --exclude=node_modules --exclude=.source.json`, {
+      diffOutput = execFileSync('diff', ['-rq', originalDir, dest, '--exclude=.git', '--exclude=node_modules', '--exclude=.source.json'], {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'ignore'],
       });

--- a/src/host/git.ts
+++ b/src/host/git.ts
@@ -1,9 +1,11 @@
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 
+const SHA_RE = /^[0-9a-f]{7,64}$/i;
+
 export function getCurrentSHA(cwd: string): string {
-  return execSync("git rev-parse HEAD", { encoding: "utf-8", cwd }).trim();
+  return execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf-8", cwd }).trim();
 }
 
 export async function getLastGoodSHA(cwd: string): Promise<string> {
@@ -22,5 +24,8 @@ export async function setLastGoodSHA(cwd: string, sha: string) {
 }
 
 export function resetToSHA(cwd: string, sha: string) {
-  execSync(`git reset --hard ${sha}`, { stdio: "inherit", cwd });
+  if (!SHA_RE.test(sha)) {
+    throw new Error(`Invalid SHA: ${sha}`);
+  }
+  execFileSync("git", ["reset", "--hard", sha], { stdio: "inherit", cwd });
 }


### PR DESCRIPTION
Fixes #39 and #40.

## Problem

Two host-side commands interpolate creature-writable data into shell strings:

1. **`git.ts` → `resetToSHA`** — runs on the host orchestrator during rollback. The SHA comes from `.sys/last_good.txt`, which lives inside the creature's bind-mounted directory. A creature that writes `$(malicious) validsha` to that file gets code execution on the host.

2. **`genome-extract.ts` → `diff -rq`** — runs as a CLI tool by the operator. `originalDir` is derived from `birth.genome` in `BIRTH.json` (creature-writable). A crafted genome name breaks out of the double-quoted interpolation.

This is distinct from #38 (which Ross correctly closed as wontfix) — those ran *inside* the creature container where the creature already has shell access. These run on the *host*.

## Fix

- **`resetToSHA`**: validate SHA against `/^[0-9a-f]{7,64}$/i` + use `execFileSync` with arg array
- **`getCurrentSHA`**: switch to `execFileSync` for consistency (no injection risk, but avoids unnecessary shell parsing)
- **`genome-extract.ts`**: switch `diff` and `git commit` calls to `execFileSync` with arg arrays

Remaining `execSync` calls in both files are static strings with no interpolation — left as-is.

## Not in scope

`supervisor.ts` and `destroy.ts` also use template-literal `execSync` (`docker stop ${containerName}`, etc.) but the container name comes from operator config, not creature-writable files — different trust boundary.