### PR TITLE
fix: replace catch (e: any) with instanceof Error guards

### DIFF
--- a/src/cli/genome-extract.ts
+++ b/src/cli/genome-extract.ts
@@ -114,9 +114,9 @@ export async function genomeExtract(opts: ExtractOptions): Promise<void> {
         stdio: ['pipe', 'pipe', 'ignore'],
       });
     }
-  } catch (e: any) {
+  } catch (e) {
     // diff returns exit code 1 when files differ, which is expected
-    if (e.stdout) diffOutput = e.stdout;
+    if (e != null && typeof e === 'object' && 'stdout' in e) diffOutput = String((e as { stdout: unknown }).stdout);
   }
 
   if (diffOutput.trim()) {

--- a/src/host/index.ts
+++ b/src/host/index.ts
@@ -672,7 +672,7 @@ export class Orchestrator {
           const model = (body.model || '').trim() || undefined;
           if (!name || !/^[a-z0-9][a-z0-9-]*$/.test(name)) throw new Error('invalid name (lowercase alphanumeric + hyphens)');
           const dir = path.join(CREATURES_DIR, name);
-          try { await fs.access(dir); throw new Error(`creature "${name}" already exists`); } catch (e: any) { if (e.message.includes('already exists')) throw e; }
+          try { await fs.access(dir); throw new Error(`creature "${name}" already exists`); } catch (e) { if (e instanceof Error && e.message.includes('already exists')) throw e; }
 
           // Return 202 immediately; spawn runs in background
           res.writeHead(202, { 'Content-Type': 'application/json' });

--- a/src/shared/spawn.ts
+++ b/src/shared/spawn.ts
@@ -83,8 +83,8 @@ export async function spawnCreature(opts: SpawnOptions): Promise<SpawnResult> {
   try {
     await fs.access(dir);
     throw new Error(`creature "${opts.name}" already exists at ${dir}`);
-  } catch (e: any) {
-    if (e.message.includes('already exists')) throw e;
+  } catch (e) {
+    if (e instanceof Error && e.message.includes('already exists')) throw e;
   }
 
   await fs.mkdir(CREATURES_DIR, { recursive: true });


### PR DESCRIPTION
Follow-up to the review on #54 — the reviewer noted three remaining `catch (e: any)` patterns that use string `.includes()` without type narrowing.

## Changes

| File | Pattern | Fix |
|------|---------|-----|
| `src/host/index.ts` | `catch (e: any) { if (e.message...) }` | `catch (e) { if (e instanceof Error && e.message...) }` |
| `src/shared/spawn.ts` | same | same |
| `src/cli/genome-extract.ts` | `catch (e: any) { if (e.stdout) ... }` | Structural type check + `String()` coercion for `execSync` error objects |

**No runtime behavior change.** The `fs.access` catch blocks still swallow non-`Error` throws (which are ENOENT in practice), and the genome-extract catch still captures diff's exit-code-1 output. The only difference is TypeScript can verify the property accesses.

Passes `tsc --noEmit` cleanly.