### PR TITLE
fix: validate creature name in genome-extract to prevent path traversal

### DIFF
--- a/src/cli/genome-extract.ts
+++ b/src/cli/genome-extract.ts
@@ -14,7 +14,14 @@ interface ExtractOptions {
   output?: string;
 }
 
+const NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+
 export async function genomeExtract(opts: ExtractOptions): Promise<void> {
+  if (!NAME_RE.test(opts.creature)) {
+    console.error(`invalid creature name "${opts.creature}" (lowercase alphanumeric + hyphens only)`);
+    process.exit(1);
+  }
+
   const srcDir = creatureDir(opts.creature);
 
   // Verify creature exists


### PR DESCRIPTION
Closes #57

`opts.creature` is passed directly to `creatureDir()` — which is just `path.join(CREATURES_DIR, name)` — without validation. A crafted name like `../../etc` resolves outside the creatures directory.

## Fix

Add the same `NAME_RE` check already used in `spawnCreature()` (spawn.ts) and `fork()` (PR #56):

```ts
const NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
if (!NAME_RE.test(opts.creature)) {
  console.error(`invalid creature name ...`);
  process.exit(1);
}
```

Validation runs before `creatureDir()` is called, so no path traversal can reach the filesystem.

One file, 7 lines added, no behavior change for valid names.