### PR TITLE
fix: validate creature name in destroy to prevent path traversal and shell injection

### DIFF
--- a/src/cli/destroy.ts
+++ b/src/cli/destroy.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { creatureDir } from "./paths.js";
@@ -9,6 +9,11 @@ interface DestroyOptions {
 }
 
 export async function destroy(opts: DestroyOptions): Promise<void> {
+  if (!opts.name || !/^[a-z0-9][a-z0-9-]*$/.test(opts.name)) {
+    console.error('invalid creature name (lowercase alphanumeric + hyphens only)');
+    process.exit(1);
+  }
+
   const dir = creatureDir(opts.name);
 
   try {
@@ -27,8 +32,8 @@ export async function destroy(opts: DestroyOptions): Promise<void> {
   }
 
   // Also try direct docker kill as fallback
-  try { execSync(`docker kill creature-${opts.name}`, { stdio: 'ignore' }); } catch {}
-  try { execSync(`docker rm -f creature-${opts.name}`, { stdio: 'ignore' }); } catch {}
+  try { execFileSync('docker', ['kill', `creature-${opts.name}`], { stdio: 'ignore' }); } catch {}
+  try { execFileSync('docker', ['rm', '-f', `creature-${opts.name}`], { stdio: 'ignore' }); } catch {}
 
   console.log(`destroying creature "${opts.name}"...`);
   await fs.rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
Closes #61.

## Two security fixes

### 1. Path traversal via unvalidated name
`creatureDir(opts.name)` joins the name directly into the path. A name like `../../etc` would resolve outside CREATURES_DIR.

**Fix:** Validate against `/^[a-z0-9][a-z0-9-]*$/` — same regex used in `spawn.ts`.

### 2. Shell injection in docker commands
`execSync(\`docker kill creature-${opts.name}\`)` passes the name through a shell. A name like `; rm -rf /` would be executed.

**Fix:** Replace `execSync` with `execFileSync`, which passes arguments as an argv array — no shell involved.

Same pattern applied in #59 for genome-extract.ts.