### PR TITLE
security: prevent container escape via BIRTH.json validate command

### DIFF
--- a/src/host/supervisor.ts
+++ b/src/host/supervisor.ts
@@ -228,6 +228,11 @@ export class CreatureSupervisor {
       '--cpus', '1.5',
       '-p', `${port}:7778`,
       '-v', `${hostDir}:/creature`,
+      // Mount host-side BIRTH.json read-only so creature cannot tamper with it.
+      // Missing for creatures spawned before this change — they fall back to mutable BIRTH.json.
+      ...(fsSync.existsSync(path.join(dir, '.host-birth.json'))
+        ? ['-v', `${hostDir}/.host-birth.json:/creature/.host-birth.json:ro`]
+        : []),
       '-v', `${cname}-node-modules:/creature/node_modules`,
       '-e', `ANTHROPIC_API_KEY=creature:${name}`,
       '-e', `ANTHROPIC_BASE_URL=${orchestratorUrl}`,

--- a/src/shared/spawn.ts
+++ b/src/shared/spawn.ts
@@ -112,7 +112,7 @@ export async function spawnCreature(opts: SpawnOptions): Promise<SpawnResult> {
     };
     await fs.writeFile(path.join(dir, 'BIRTH.json'), JSON.stringify(birth, null, 2) + '\n');
 
-    // Write a host-side copy that the creature cannot modify.
+    // Write a host-side copy; mounted read-only into the container (see supervisor.ts).
     // The orchestrator reads this copy for model/validate fields.
     const hostMeta = path.join(dir, '.host-birth.json');
     await fs.writeFile(hostMeta, JSON.stringify(birth, null, 2) + '\n');


### PR DESCRIPTION
## Problem

Issue #11 identified a critical container escape vulnerability: creatures can modify their own `BIRTH.json` to inject arbitrary commands into the `validate` field. The orchestrator then runs `execAsync(validate, { cwd: dir })` **on the host**, giving the creature host-level code execution.

## Fix (three layers)

**1. Run validation inside the container** (`docker exec`)  
The `validate` command now runs via `docker exec ${containerName} sh -c ...` instead of directly on the host. Even if a creature modifies its validate command, execution is sandboxed.

**2. Immutable host-side birth metadata** (`.host-birth.json`)  
At spawn time, we write a second copy of BIRTH.json to `.host-birth.json` in the creature directory. The orchestrator reads from this copy (with fallback to BIRTH.json for existing creatures). Since this file exists outside the creature's container filesystem, it cannot be modified by the creature.

**3. Centralized `readBirthField()` helper**  
All host-side BIRTH.json reads now go through a single function that prefers the immutable copy.

## Changes

- `src/host/index.ts`: Add `readBirthField()` helper; refactor validate + model reads; use `docker exec` for validation
- `src/host/supervisor.ts`: Expose `getContainerName()` public accessor
- `src/shared/spawn.ts`: Write `.host-birth.json` at spawn time

Fixes #11