### PR TITLE
feat: remount — recreate containers preserving writable layer

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -72,7 +72,7 @@ export async function fetchGenomes(): Promise<GenomeInfo[]> {
   return res.json();
 }
 
-export async function creatureAction(name: string, action: 'start' | 'stop' | 'restart' | 'rebuild' | 'wake' | 'archive', method = 'POST'): Promise<void> {
+export async function creatureAction(name: string, action: 'start' | 'stop' | 'restart' | 'rebuild' | 'remount' | 'wake' | 'archive', method = 'POST'): Promise<void> {
   await fetch(`/api/creatures/${name}/${action}`, { method });
 }
 


### PR DESCRIPTION
## Problem

Docker doesn't support adding volume mounts to existing containers. When `createContainer()` gains new mounts (like the `/board` directory from #65), existing creatures can't pick them up without a full rebuild — which destroys their writable layer (self-installed packages like supervisord, python libraries, custom configs, etc.).

`restart` preserves the writable layer but keeps the old mounts.
`rebuild` picks up new mounts but wipes the writable layer.

There's no middle ground.

## Solution

Adds a `remount` command that:

1. **Stops** the container
2. **Commits** the container's current state (writable layer) into its image via `docker commit`
3. **Removes** the old container
4. **Creates** a fresh container from the updated image via the existing `spawnCreature()` flow

The new container picks up any changes to volume mounts, env vars, or network config in `createContainer()`, while the committed image preserves everything the creature installed or configured.

## How to trigger

- **Dashboard**: Click the "remount" button on a creature's detail page (with confirmation dialog)
- **API**: `POST /api/creatures/:name/remount`
- **curl**: `curl -X POST http://localhost:7770/api/creatures/wondrous/remount`

## When to use

- After adding new volume mounts to `createContainer()` (e.g. `/board`)
- After changing env vars or network config
- Anytime you need to "upgrade" a container's configuration without losing its installed state

## What it doesn't do

- Does NOT rebuild the Docker image from the Dockerfile (use `rebuild` for that)
- Does NOT preserve running process state (supervisord etc. will need to restart, but their binaries and configs survive)
- Volume-mounted paths (`/creature`, node_modules) are unaffected — they're external storage

## Changes

- `supervisor.ts`: `remount()` method
- `index.ts`: `remountCreature()` + `POST /api/creatures/:name/remount` route
- `CreatureDetail.tsx`: remount button with confirmation dialog


Made with [Cursor](https://cursor.com)