### PR TITLE
fix: add missing event types for budget + spawn events

### DIFF
--- a/src/host/index.ts
+++ b/src/host/index.ts
@@ -494,7 +494,7 @@ export class Orchestrator {
       type: 'budget.exceeded',
       daily_spent: this.costs.getCreatureDailyCost(name),
       daily_cap: getSpendingCap(name).daily_usd,
-    } as any);
+    });
   }
 
   private async checkBudgetResets() {
@@ -505,7 +505,7 @@ export class Orchestrator {
         console.log(`[${name}] daily budget reset, waking creature`);
         try {
           await supervisor.start();
-          await this.emitEvent(name, { t: new Date().toISOString(), type: 'budget.reset' } as any);
+          await this.emitEvent(name, { t: new Date().toISOString(), type: 'budget.reset' });
         } catch (err: any) {
           console.error(`[${name}] failed to wake after budget reset:`, err.message);
         }
@@ -685,13 +685,13 @@ export class Orchestrator {
           res.end(JSON.stringify({ ok: true, name, status: 'spawning' }));
 
           this.pendingOps.add(name);
-          await this.emitEvent(name, { type: 'creature.spawning', t: new Date().toISOString() } as any);
+          await this.emitEvent(name, { type: 'creature.spawning', t: new Date().toISOString() });
           this.spawnCreature(name, dir, purpose, genome, model).then(async () => {
             console.log(`[orchestrator] creature "${name}" ready`);
-            await this.emitEvent(name, { type: 'creature.spawned', t: new Date().toISOString() } as any);
+            await this.emitEvent(name, { type: 'creature.spawned', t: new Date().toISOString() });
           }).catch(async (err) => {
             console.error(`[orchestrator] spawn failed for "${name}":`, err);
-            await this.emitEvent(name, { type: 'creature.spawn_failed', t: new Date().toISOString(), error: err.message } as any);
+            await this.emitEvent(name, { type: 'creature.spawn_failed', t: new Date().toISOString(), error: err.message });
           }).finally(() => {
             this.pendingOps.delete(name);
           });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,7 +17,9 @@ export type HostEvent =
   | { t: string; type: "host.promote"; sha: string }
   | { t: string; type: "host.rollback"; from: string; to: string; reason: string }
   | { t: string; type: "host.infra_failure"; reason: string }
-  | { t: string; type: "orchestrator.status" } & OrchestratorHealth;
+  | { t: string; type: "orchestrator.status" } & OrchestratorHealth
+  | { t: string; type: "budget.exceeded"; daily_spent: number; daily_cap: number }
+  | { t: string; type: "budget.reset" };
 
 // Universal creature lifecycle events (orchestrator interprets these)
 export type CreatureLifecycleEvent =
@@ -28,7 +30,10 @@ export type CreatureLifecycleEvent =
   | { t: string; type: "creature.wake"; reason: string; source: "manual" | "timer" | "external" }
   | { t: string; type: "creature.message"; text: string; source: "user" | "system" }
   | { t: string; type: "creature.error"; error: string; retryIn?: number; retries?: number; fatal?: boolean }
-  | { t: string; type: "creature.request_restart"; reason: string };
+  | { t: string; type: "creature.request_restart"; reason: string }
+  | { t: string; type: "creature.spawning" }
+  | { t: string; type: "creature.spawned" }
+  | { t: string; type: "creature.spawn_failed"; error: string };
 
 // Genome-specific events. The host relays these but doesn't interpret them.
 // Genomes can emit any event type with any fields.


### PR DESCRIPTION
Closes #72

## Problem

`src/host/index.ts` emits several event types that aren't in the `HostEvent` or `CreatureLifecycleEvent` unions, requiring `as any` casts that defeat type safety.

## Solution

Added the missing event variants to `src/shared/types.ts`:

**HostEvent** (budget events):
- `budget.exceeded` — with `daily_spent` and `daily_cap`
- `budget.reset`

**CreatureLifecycleEvent** (spawn events):
- `creature.spawning`
- `creature.spawned`  
- `creature.spawn_failed` — with `error` field

Then removed all 5 `as any` casts from the corresponding `emitEvent` calls in `src/host/index.ts`.

## Changes

- `src/shared/types.ts`: +5 event type variants
- `src/host/index.ts`: -5 `as any` casts (now fully type-checked)

Two legitimate `as any` casts remain at lines 373 and 437 — those access dynamic fields on narrowed event types and are separate concerns.