### PR TITLE
fix: remove dead subconscious NOTHING/unsurfaced code paths

### DIFF
--- a/dashboard/src/components/Event.tsx
+++ b/dashboard/src/components/Event.tsx
@@ -122,14 +122,11 @@ export function Event({ ev, showCreature }: { ev: CreatureEvent; showCreature?: 
       </>
     );
   } else if (t === 'creature.subconscious') {
-    const surfaced = ev.surfaced !== false && ev.memory && ev.memory !== 'NOTHING';
     body = (
       <>
         {cl}
         <span className="font-bold ml-2 text-[#7c3aed] italic">subconscious</span>
-        {surfaced
-          ? <Expandable summary={<span className="text-text-primary ml-1"> - {summarize(ev.memory || '', 120)}</span>}>{ev.memory || ''}</Expandable>
-          : <span className="text-text-muted ml-1 text-[11px]">NOTHING</span>}
+        <Expandable summary={<span className="text-text-primary ml-1"> - {summarize(ev.memory || '', 120)}</span>}>{ev.memory || ''}</Expandable>
       </>
     );
   } else if (t === 'creature.progress_check') {

--- a/genomes/wonders/src/index.ts
+++ b/genomes/wonders/src/index.ts
@@ -140,7 +140,7 @@ class Creature {
           await this.emit({ type: "creature.error", error, retryIn, retries } as any);
         },
         async (memory, candidateCount) => {
-          await this.emit({ type: "creature.subconscious", memory: memory || "NOTHING", surfaced: memory !== null, candidateCount } as any);
+          await this.emit({ type: "creature.subconscious", memory, surfaced: true, candidateCount });
         },
       );
     } catch (err) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -34,7 +34,8 @@ export type CreatureLifecycleEvent =
   | { t: string; type: "creature.request_restart"; reason: string }
   | { t: string; type: "creature.spawning" }
   | { t: string; type: "creature.spawned" }
-  | { t: string; type: "creature.spawn_failed"; error: string };
+  | { t: string; type: "creature.spawn_failed"; error: string }
+  | { t: string; type: "creature.subconscious"; memory: string; surfaced: true; candidateCount: number };
 
 // Genome-specific events. The host relays these but doesn't interpret them.
 // Using a template literal type ensures TypeScript can narrow the Event union


### PR DESCRIPTION
## Problem

The `onSubconscious` callback only fires inside the `if (memory)` block in `mind.ts`, so `memory` is always a non-null string and `surfaced` is always true. This created several dead code paths:

- **Event.tsx**: The `NOTHING` branch was unreachable — `ev.surfaced` was never false and `ev.memory` was never `'NOTHING'`
- **index.ts**: `memory || "NOTHING"` fallback never triggered; `surfaced: memory !== null` was always true
- **types.ts**: `creature.subconscious` wasn't in the `CreatureLifecycleEvent` union, requiring an `as any` cast

## Changes

1. **`genomes/wonders/src/index.ts`** — Simplify emitter: pass `memory` directly with `surfaced: true` literal, remove `as any` cast
2. **`dashboard/src/components/Event.tsx`** — Remove unreachable NOTHING/unsurfaced branch
3. **`src/shared/types.ts`** — Add `creature.subconscious` to `CreatureLifecycleEvent` union

## Why this matters

Dead code that handles impossible states makes the codebase harder to reason about and obscures the actual behavior. The `as any` cast was also hiding a missing type definition.

Closes #68