### PR TITLE
blog: teaching creatures to see

### DIFF
--- a/site/src/content/blog/creature-vision.md
+++ b/site/src/content/blog/creature-vision.md
@@ -34,7 +34,7 @@ For local files (screenshots the creature captured, downloaded attachments):
 
 ```typescript
 const result = await see({
-  file_path: '/tmp/capture.png'
+  path: '/tmp/capture.png'
 });
 ```
 
@@ -82,7 +82,7 @@ We restrict to four image formats: JPEG, PNG, GIF, and WebP. That's what Anthrop
 If the creature tries to see an unsupported format, it gets an actionable error:
 
 ```
-Unsupported image type: image/svg+xml. Supported: image/jpeg, image/png, image/gif, image/webp
+Unsupported image type: image/svg+xml. Supported types: JPEG, PNG, GIF, WebP.
 ```
 
 This is better than the alternative — encoding an SVG as base64, sending it to the API, and getting a confusing model response about not being able to see anything.


### PR DESCRIPTION
Draft blog post covering the `see` tool — what it does, why it works this way, and what it enables.

Ties into PR #91 (the actual implementation). Written to match the existing blog tone.

**Content:**
- The problem: creatures are blind to images
- How the see tool works (URL + local file)
- Why we fetch/encode rather than pass URLs (auth, ephemeral, control)
- What vision enables (UI review, diagram reading, chart analysis)
- Constraints (4 supported formats, explicit errors)
- What's next (browser integration, visual regression)

Happy to adjust tone, length, or focus.