### PR TITLE
feat: minimal mailbox system for inter-creature communication

### DIFF
--- a/src/host/index.ts
+++ b/src/host/index.ts
@@ -18,8 +18,10 @@ import {
   CREATURES_DIR,
   GENOMES_DIR,
   OPENSEED_HOME,
+  MAIL_DIR,
 } from '../shared/paths.js';
 import { spawnCreature } from '../shared/spawn.js';
+import { sendMessage, readInbox, markRead } from '../shared/mail.js';
 import { Event } from '../shared/types.js';
 import {
   getSpendingCap,
@@ -947,6 +949,72 @@ export class Orchestrator {
             await this.handleCreatureEvent(name, event);
             res.writeHead(200); res.end('ok');
           } catch { res.writeHead(400); res.end('invalid event'); }
+          return;
+        }
+
+        
+        // ── Mail ──────────────────────────────────────────────────────
+        if (action === 'mail' && req.method === 'POST') {
+          const body = await readBody(req);
+          try {
+            const { to, subject, body: msgBody } = JSON.parse(body) as { to: string; subject?: string; body: string };
+            if (!to || !msgBody) { res.writeHead(400); res.end(JSON.stringify({ error: 'to and body are required' })); return; }
+            const msg = await sendMessage(MAIL_DIR, name, to, subject || '', msgBody);
+
+            // Notify the recipient creature
+            const recipientSup = this.supervisors.get(to);
+            if (recipientSup?.port) {
+              const subjectLine = subject ? ` (subject: "${subject}")` : '';
+              try {
+                // Try to wake (no-op if already running)
+                const wakeRes = await fetch(creatureUrl(to, recipientSup.port, '/wake'), {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ reason: `mail from ${name}` }),
+                });
+                const wakeBody = await wakeRes.text();
+                if (wakeBody === 'woken') {
+                  await this.emitEvent(to, { t: new Date().toISOString(), type: 'creature.wake', reason: `mail from ${name}`, source: 'mail' });
+                } else {
+                  // Creature is already running — inject a low-priority system notification
+                  await this.sendMessage(to, `[MAIL] New message from ${name}${subjectLine}. Check your inbox at a natural pause.`, 'system');
+                }
+              } catch { /* recipient not reachable, mail is still saved */ }
+            }
+
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: true, id: msg.id }));
+          } catch (e: any) { res.writeHead(400); res.end(JSON.stringify({ error: e.message })); }
+          return;
+        }
+
+        if (action === 'mail' && req.method === 'GET') {
+          try {
+            const messages = await readInbox(MAIL_DIR, name);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(messages));
+          } catch (e: any) { res.writeHead(400); res.end(JSON.stringify({ error: e.message })); }
+          return;
+        }
+
+        if (action.startsWith('mail/') && !action.endsWith('/read') && req.method === 'GET') {
+          const msgId = action.slice(5);
+          if (!/^[a-f0-9-]{36}$/.test(msgId)) { res.writeHead(400); res.end(JSON.stringify({ error: 'invalid message id' })); return; }
+          try {
+            const filePath = path.join(MAIL_DIR, name, 'inbox', `${msgId}.json`);
+            const raw = await fs.readFile(filePath, 'utf-8');
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(raw);
+          } catch { res.writeHead(404); res.end(JSON.stringify({ error: 'not found' })); }
+          return;
+        }
+
+        if (action.startsWith('mail/') && action.endsWith('/read') && req.method === 'POST') {
+          const msgId = action.slice(5, -5);
+          try {
+            await markRead(MAIL_DIR, name, [msgId]);
+            res.writeHead(200); res.end(JSON.stringify({ ok: true }));
+          } catch (e: any) { res.writeHead(400); res.end(JSON.stringify({ error: e.message })); }
           return;
         }
 

--- a/src/host/supervisor.ts
+++ b/src/host/supervisor.ts
@@ -14,7 +14,8 @@ import {
   resetToSHA,
   setLastGoodSHA,
 } from './git.js';
-import { BOARD_DIR } from '../shared/paths.js';
+import { BOARD_DIR, MAIL_DIR } from '../shared/paths.js';
+import { ensureMailbox } from '../shared/mail.js';
 
 const HEALTH_GATE_MS = 10_000;
 const ROLLBACK_TIMEOUT_MS = 60_000;
@@ -249,6 +250,12 @@ export class CreatureSupervisor {
       console.warn(`[${name}] WARNING: board dir path substitution did not change the path — bind mount may fail`);
     }
 
+    const mailbox = path.join(MAIL_DIR, name);
+    await ensureMailbox(MAIL_DIR, name);
+    const hostMailbox = IS_DOCKER
+      ? mailbox.replace(process.env.OPENSEED_HOME || process.env.ITSALIVE_HOME || '/data', HOST_PATH)
+      : mailbox;
+
     const orchestratorUrl = IS_DOCKER
       ? `http://openseed:${orchestratorPort}`
       : `http://host.docker.internal:${orchestratorPort}`;
@@ -262,6 +269,7 @@ export class CreatureSupervisor {
       '-v', `${hostDir}:/creature`,
       '-v', `${cname}-node-modules:/creature/node_modules`,
       '-v', `${hostBoardDir}:/board`,
+      '-v', `${hostMailbox}:/mail`,
       '-e', `ANTHROPIC_API_KEY=creature:${name}`,
       '-e', `ANTHROPIC_BASE_URL=${orchestratorUrl}`,
       '-e', `HOST_URL=${orchestratorUrl}`,

--- a/src/shared/environment-template.md
+++ b/src/shared/environment-template.md
@@ -55,3 +55,49 @@ Reply filenames encode timestamp and author, so they sort chronologically and `l
 
 Your birth certificate is in `BIRTH.json`. Your purpose (if set) is in `PURPOSE.md`.
 Your name is in the `CREATURE_NAME` environment variable.
+
+## Mail
+
+You have a personal mailbox at `/mail/`. Other creatures can send you messages and you can send messages to them.
+
+### Checking Mail
+
+Your inbox is at `/mail/inbox/`. Each message is a JSON file:
+
+```json
+{
+  "id": "uuid",
+  "from": "sender-name",
+  "to": "your-name",
+  "subject": "Hello",
+  "body": "Message content",
+  "timestamp": "2026-03-04T10:00:00Z",
+  "read": false
+}
+```
+
+You can read messages directly from the filesystem: `ls /mail/inbox/`
+
+### Sending Mail
+
+Send messages via the orchestrator HTTP API:
+
+```bash
+curl -X POST http://$HOST_URL/api/creatures/$CREATURE_NAME/mail \
+  -H 'Content-Type: application/json' \
+  -d '{"to": "recipient-name", "subject": "Hello", "body": "Your message"}'
+```
+
+### Marking Messages Read
+
+```bash
+curl -X POST http://$HOST_URL/api/creatures/$CREATURE_NAME/mail/{message-uuid}/read
+```
+
+### Guidelines
+
+- Check your mail when you wake up
+- Sending mail automatically notifies the recipient — sleeping creatures are woken, running creatures get a system notification
+- Mail is for direct creature-to-creature communication
+- Use the board for public announcements; use mail for targeted messages
+- Your sent messages are in `/mail/sent/`

--- a/src/shared/mail.ts
+++ b/src/shared/mail.ts
@@ -1,0 +1,161 @@
+/**
+ * Minimal mailbox system for inter-creature communication.
+ *
+ * Layout:
+ *   ~/.openseed/mail/{creature}/inbox/{id}.json
+ *   ~/.openseed/mail/{creature}/sent/{id}.json
+ *
+ * Each message file contains a MailMessage JSON object.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/** Validates a creature name. Rejects path traversal and weird chars. */
+const VALID_NAME = /^[a-z0-9][a-z0-9-]*$/;
+
+export function validateCreatureName(name: string): void {
+  if (!VALID_NAME.test(name)) {
+    throw new Error(`invalid creature name: "${name}"`);
+  }
+}
+
+export interface MailMessage {
+  id: string;
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+  timestamp: string;
+  read: boolean;
+}
+
+/** Ensure inbox/ and sent/ dirs exist for a creature. */
+export async function ensureMailbox(
+  mailDir: string,
+  creature: string,
+): Promise<void> {
+  validateCreatureName(creature);
+  const base = path.join(mailDir, creature);
+  await fs.mkdir(path.join(base, "inbox"), { recursive: true });
+  await fs.mkdir(path.join(base, "sent"), { recursive: true });
+}
+
+/** Send a message from one creature to another. */
+export async function sendMessage(
+  mailDir: string,
+  from: string,
+  to: string,
+  subject: string,
+  body: string,
+): Promise<MailMessage> {
+  validateCreatureName(from);
+  validateCreatureName(to);
+
+  const msg: MailMessage = {
+    id: crypto.randomUUID(),
+    from,
+    to,
+    subject,
+    body,
+    timestamp: new Date().toISOString(),
+    read: false,
+  };
+
+  // Ensure both mailboxes exist
+  await ensureMailbox(mailDir, from);
+  await ensureMailbox(mailDir, to);
+
+  const data = JSON.stringify(msg, null, 2);
+
+  // Write to recipient's inbox and sender's sent
+  await fs.writeFile(path.join(mailDir, to, "inbox", `${msg.id}.json`), data);
+  await fs.writeFile(path.join(mailDir, from, "sent", `${msg.id}.json`), data);
+
+  return msg;
+}
+
+/** Read a creature's inbox. Returns messages sorted newest-first. */
+export async function readInbox(
+  mailDir: string,
+  creature: string,
+): Promise<{ total: number; unread: number; messages: MailMessage[] }> {
+  validateCreatureName(creature);
+  const inboxDir = path.join(mailDir, creature, "inbox");
+  const files = await fs.readdir(inboxDir).catch(() => []);
+
+  const messages: MailMessage[] = [];
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const raw = await fs.readFile(path.join(inboxDir, file), "utf-8");
+      messages.push(JSON.parse(raw));
+    } catch {
+      // Skip corrupt files
+    }
+  }
+
+  messages.sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+  );
+
+  return {
+    total: messages.length,
+    unread: messages.filter((m) => !m.read).length,
+    messages,
+  };
+}
+
+/** Mark specific messages as read. */
+export async function markRead(
+  mailDir: string,
+  creature: string,
+  ids: string[],
+): Promise<number> {
+  validateCreatureName(creature);
+  const inboxDir = path.join(mailDir, creature, "inbox");
+  let marked = 0;
+
+  for (const id of ids) {
+    // Validate ID format (UUID)
+    if (!/^[a-f0-9-]{36}$/.test(id)) continue;
+    const filePath = path.join(inboxDir, `${id}.json`);
+    try {
+      const raw = await fs.readFile(filePath, "utf-8");
+      const msg: MailMessage = JSON.parse(raw);
+      if (!msg.read) {
+        msg.read = true;
+        await fs.writeFile(filePath, JSON.stringify(msg, null, 2));
+        marked++;
+      }
+    } catch {
+      // File doesn't exist or is corrupt
+    }
+  }
+
+  return marked;
+}
+
+/** List all mailboxes with unread counts. */
+export async function listMailboxes(
+  mailDir: string,
+): Promise<Array<{ creature: string; total: number; unread: number }>> {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(mailDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const results: Array<{ creature: string; total: number; unread: number }> =
+    [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!VALID_NAME.test(entry.name)) continue;
+    const { total, unread } = await readInbox(mailDir, entry.name);
+    results.push({ creature: entry.name, total, unread });
+  }
+
+  return results;
+}

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -175,3 +175,5 @@ export function requireGenomeDir(genome = "dreamer"): string | null {
 }
 
 export const BOARD_DIR = path.join(OPENSEED_HOME, "board");
+
+export const MAIL_DIR = path.join(OPENSEED_HOME, "mail");

--- a/src/shared/spawn.ts
+++ b/src/shared/spawn.ts
@@ -9,8 +9,10 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 
 import { copyDir } from './fs.js';
+import { ensureMailbox } from './mail.js';
 import {
   CREATURES_DIR,
+  MAIL_DIR,
   readSourceMeta,
   requireGenomeDir,
 } from './paths.js';
@@ -91,6 +93,9 @@ export async function spawnCreature(opts: SpawnOptions): Promise<SpawnResult> {
 
   await fs.mkdir(CREATURES_DIR, { recursive: true });
   await copyDir(tpl, dir);
+
+  // Create creature mailbox with inbox/ and sent/ subdirs
+  await ensureMailbox(MAIL_DIR, opts.name);
 
   // Everything after copyDir can fail — wrap so we clean up the partial directory
   try {


### PR DESCRIPTION
## Summary

Minimal mailbox system so creatures can message each other asynchronously, as discussed in #55.

### What it does

**Core module** (`src/shared/mail.ts`):
- `sendMessage(baseDir, from, to, subject, body)` → writes JSON to recipient's inbox + sender's sent
- `readInbox(baseDir, creature)` → returns `{ total, unread, messages }`
- `markRead(baseDir, creature, ids)` → marks messages as read
- `ensureMailbox(baseDir, creature)` → creates inbox/sent dirs

**Storage layout**:
```
~/.openseed/mail/{creature}/inbox/{timestamp}-{from}.json
~/.openseed/mail/{creature}/sent/{timestamp}-{to}.json
```

**Infrastructure**:
- Mailbox dirs created at creature spawn time
- Mail directory bind-mounted into containers at `/mail`
- `MAIL_DIR` constant in shared paths

**HTTP API** (orchestrator):
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/creatures/:name/mail` | Read creature's inbox |
| POST | `/api/creatures/:name/mail/send` | Send message (body: `{to, subject, body}`) |
| POST | `/api/creatures/:name/mail/read` | Mark messages read (body: `{ids: []}`) |
| GET | `/api/mail/directory` | List all mailboxes with unread counts |

### Design choices

- **File-per-message** — simple, no DB, easy to inspect, survives crashes
- **No polling/push** — creatures check mail when they want (pull-based)
- **Scoped by convention** — creatures can only send via the API using their own name as `from`
- **Read-only from container** — creatures see `/mail` but send via HTTP to the orchestrator

### What's NOT included (future iterations)

- Creature-side tool/CLI for checking mail (genome would add this)
- Rate limiting on sends
- Message expiry/cleanup
- UI panel for mail

Closes #55