### PR TITLE
fix: wrap board API responses in envelope for consistency with mail

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -212,10 +212,13 @@ export async function fetchBoardPosts(opts?: { limit?: number; before?: string; 
   if (opts?.author) params.set('author', opts.author);
   const qs = params.toString();
   const res = await fetch(`/api/board${qs ? `?${qs}` : ''}`).then(requireOk);
-  return res.json();
+  const data = await res.json();
+  return data.posts;
 }
 
 export async function fetchBoardPost(id: string): Promise<import('./types').BoardPost> {
   const res = await fetch(`/api/board/${id}`).then(requireOk);
-  return res.json();
+  const data = await res.json();
+  // Thread envelope: { post, replies, reply_count }
+  return { ...data.post, replies: data.replies };
 }

--- a/src/shared/board.ts
+++ b/src/shared/board.ts
@@ -75,9 +75,23 @@ export interface ListPostsOpts {
   author?: string;
 }
 
-export function listPosts(opts: ListPostsOpts = {}): BoardPost[] {
+export interface BoardListResult {
+  posts: BoardPost[];
+  total: number;
+}
+
+export function listPosts(opts: ListPostsOpts = {}): BoardListResult {
   const d = getDb();
   const limit = Math.min(opts.limit || 50, 200);
+
+  // Count total top-level posts (respecting author filter)
+  let countSql = 'SELECT COUNT(*) AS c FROM posts WHERE parent_id IS NULL';
+  const countParams: any[] = [];
+  if (opts.author) {
+    countSql += ' AND author = ?';
+    countParams.push(opts.author);
+  }
+  const total = (d.prepare(countSql).get(...countParams) as any).c;
 
   let sql = `
     SELECT p.*, (SELECT COUNT(*) FROM posts r WHERE r.parent_id = p.id) AS reply_count
@@ -98,10 +112,17 @@ export function listPosts(opts: ListPostsOpts = {}): BoardPost[] {
   sql += ' ORDER BY p.created_at DESC LIMIT ?';
   params.push(limit);
 
-  return d.prepare(sql).all(...params).map(rowToPost);
+  const posts = d.prepare(sql).all(...params).map(rowToPost);
+  return { posts, total };
 }
 
-export function getPost(id: string): (BoardPost & { replies: BoardPost[] }) | null {
+export interface BoardThreadResult {
+  post: BoardPost;
+  replies: BoardPost[];
+  reply_count: number;
+}
+
+export function getPost(id: string): BoardThreadResult | null {
   const d = getDb();
   const row = d.prepare(`
     SELECT p.*, (SELECT COUNT(*) FROM posts r WHERE r.parent_id = p.id) AS reply_count
@@ -113,14 +134,21 @@ export function getPost(id: string): (BoardPost & { replies: BoardPost[] }) | nu
     SELECT * FROM posts WHERE parent_id = ? ORDER BY created_at ASC
   `).all(id).map(rowToPost);
 
-  return { ...rowToPost(row), replies };
+  const post = rowToPost(row);
+  return { post, replies, reply_count: post.reply_count ?? replies.length };
 }
 
-export function getReplies(postId: string): BoardPost[] {
+export interface BoardRepliesResult {
+  replies: BoardPost[];
+  reply_count: number;
+}
+
+export function getReplies(postId: string): BoardRepliesResult {
   const d = getDb();
-  return d.prepare(`
+  const replies = d.prepare(`
     SELECT * FROM posts WHERE parent_id = ? ORDER BY created_at ASC
   `).all(postId).map(rowToPost);
+  return { replies, reply_count: replies.length };
 }
 
 function rowToPost(row: any): BoardPost {

--- a/src/shared/environment-template.md
+++ b/src/shared/environment-template.md
@@ -33,12 +33,14 @@ Browse recent posts:
 ```bash
 curl http://$HOST_URL/api/board
 curl http://$HOST_URL/api/board?limit=20&author=proof-ops
+# Returns: { posts: [...], total: N }
 ```
 
 Get a specific post with its replies:
 
 ```bash
 curl http://$HOST_URL/api/board/<post-uuid>
+# Returns: { post: {...}, replies: [...], reply_count: N }
 ```
 
 ### Guidelines


### PR DESCRIPTION
Closes #105

Wraps all board read endpoints in envelope objects to match the mail API shape.

### Changes

**`listPosts()`** — was bare `BoardPost[]`, now:
```json
{ "posts": [...], "total": 42 }
```

**`getPost()`** — was `BoardPost & { replies }`, now:
```json
{ "post": {...}, "replies": [...], "reply_count": 3 }
```

**`getReplies()`** — was bare `BoardPost[]`, now:
```json
{ "replies": [...], "reply_count": 2 }
```

**Dashboard** — updated `fetchBoardPosts` and `fetchBoardPost` to unwrap the new envelopes so the UI is unaffected.

---

One question: you mentioned updating `environment.md` — I don't see an existing API doc file. Should I create one as part of this PR, or is there a different place you'd like the routes documented?